### PR TITLE
Fix Happy Ghast speed not resetting to default on tame and dismount

### DIFF
--- a/src/main/kotlin/io/github/derec4/fasterHappyGhast/listeners/HappyGhastDismountListener.kt
+++ b/src/main/kotlin/io/github/derec4/fasterHappyGhast/listeners/HappyGhastDismountListener.kt
@@ -18,7 +18,7 @@ class HappyGhastDismountListener: Listener {
         }
 
         // Only remove speed boost if no passengers remain after this dismount
-        // Bug credits: @DavidS-Repo
+        // Bug credits: @DavidS-Repo, @ricdrip
         // https://github.com/Derec-Mods/FasterHappyGhast/issues/1
         val remaining = happyGhast.passengers.filter { it != event.entity }
         if (remaining.isEmpty()) {

--- a/src/main/kotlin/io/github/derec4/fasterHappyGhast/listeners/HappyGhastDismountListener.kt
+++ b/src/main/kotlin/io/github/derec4/fasterHappyGhast/listeners/HappyGhastDismountListener.kt
@@ -20,7 +20,8 @@ class HappyGhastDismountListener: Listener {
         // Only remove speed boost if no passengers remain after this dismount
         // Bug credits: @DavidS-Repo
         // https://github.com/Derec-Mods/FasterHappyGhast/issues/1
-        if (happyGhast.passengers.isEmpty()) {
+        val remaining = happyGhast.passengers.filter { it != event.entity }
+        if (remaining.isEmpty()) {
             happyGhast.getAttribute(Attribute.FLYING_SPEED)?.baseValue = FasterHappyGhast.defaultSpeed
         }
     }

--- a/src/main/kotlin/io/github/derec4/fasterHappyGhast/listeners/HappyGhastTameListener.kt
+++ b/src/main/kotlin/io/github/derec4/fasterHappyGhast/listeners/HappyGhastTameListener.kt
@@ -17,6 +17,6 @@ class HappyGhastTameListener: Listener {
             return;
         }
 
-        happyGhast.getAttribute(Attribute.FLYING_SPEED)?.baseValue = FasterHappyGhast.baseSpeed;
+        happyGhast.getAttribute(Attribute.FLYING_SPEED)?.baseValue = FasterHappyGhast.defaultSpeed;
     }
 }


### PR DESCRIPTION
Problem: 
1. when a tamed ghast was dismounted, the ghast would remain at ridden speed.
2. a tamed but never ridden ghast flew at the boosted speed permanently.

Solution: 
HappyGhastTameListener: replaced default-speed instead of base-speed. When a ghast is freshly tamed, it will remain at the default-speed, once mounted it will change to base-speed.
HappyGhastDismountListener: filter the dismounting entity out of the passenger list before checking if a player is mounted. When a solo rider dismounts, the ghast resets to default-speed. When multiple riders are mounted, the ghast will remain at the boosted speed until the final rider dismounts. 

Testing: 
tested on Paper 26.1.2 (java 25): 

Tamed a happy ghast and flew it without mounting, stayed at default speed (0.05).
Mounted a tamed ghast, sped up to base-speed.
with two riders, ghast remains at boosted speeds when second player dismounts, ghast returns to base-speed when final player dismounts 
 